### PR TITLE
Fix: Correct syntax error in generate API route

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -911,7 +911,3 @@ module.exports = nextConfig;`,
     );
   }
 }
-    }
-    )
-  }
-}


### PR DESCRIPTION
Removes extraneous closing braces and parenthesis at the end of the file app/api/generate/route.ts.

This error prevented the /api/generate route from compiling, causing a 500 error when attempting to generate a site. The removal of these characters allows the route to compile successfully.